### PR TITLE
Update Vue CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "vue2-leaflet": "^1.2.3"
   },
   "devDependencies": {
-    "@vue/cli-service": "^4.1.2",
+    "@vue/cli-service": "^4.4.5",
     "vue-template-compiler": "^2.5.22"
   }
 }


### PR DESCRIPTION
I updated vue-cli as all other openEO Vue projects recently have been updated, too.

For the Hub it was pretty straightforward and should not have any negative side effects as it's the only openEO Vue project that (a) was already using 4.x and not 3.x anymore and (b) is not using the vue-cli-babel plugin (and I'm wondering whether it should be added here for better cross-browser support).