### PR TITLE
Replace "VITO" backend (URL) with "Terrascope"

### DIFF
--- a/config.js
+++ b/config.js
@@ -4,7 +4,8 @@ module.exports = {
         "openEO Platform": "https://openeo.cloud/",
         "Google Earth Engine": "https://earthengine.openeo.org/",
         "EURAC": "https://openeo.eurac.edu/",
-        "TerraScope": "https://openeo.terrascope.be/",
+        // Note: the "Terrascope" backend was originally referred to as "VITO"
+        "Terrascope": "https://openeo.terrascope.be/",
         "EODC": "https://openeo.eodc.eu/",
         // mundials was offline last time we checked, might have been discontinued
         // "mundialis": "https://openeo.mundialis.de/",


### PR DESCRIPTION
openeo.vito.be is in process of being migrated/replaced with openeo.terrascope.be

this PR updates the hub config about that


refs https://github.com/eu-cdse/openeo-cdse-infra/issues/1069